### PR TITLE
Add abstract glowing shape prompt

### DIFF
--- a/prompts/abstract_glowing_shape.txt
+++ b/prompts/abstract_glowing_shape.txt
@@ -1,0 +1,11 @@
+# Abstract Glowing Shape Prompt
+
+## Positive Prompt
+abstract symmetrical sigil, radiant neon blue and molten gold ribbons weaving into a luminous geometric mandala, intricate circuitry details, volumetric light, ethereal glow, high-detail digital illustration, 8k, artstation trending
+
+## Negative Prompt
+low detail, blurry, noisy, monochrome, muted colors, text, watermark, artifacts, grainy, distorted anatomy, asymmetry, cropped
+
+## Notes
+- Pair with a high CFG scale to preserve crisp neon edges.
+- Works well with Euler a or DPM++ 2M Karras samplers at 25-30 steps.


### PR DESCRIPTION
## Summary
- add a ready-to-use prompt for generating a neon blue and gold abstract glowing pattern
- include suggested sampler guidance and a curated negative prompt

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbf3a076748327a941b9e088485ca4